### PR TITLE
set context class loader to AgentClassLoader

### DIFF
--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/loader/AgentClassLoader.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/loader/AgentClassLoader.java
@@ -77,6 +77,7 @@ public class AgentClassLoader extends ClassLoader {
             synchronized (AgentClassLoader.class) {
                 if (DEFAULT_LOADER == null) {
                     DEFAULT_LOADER = new AgentClassLoader(PluginBootstrap.class.getClassLoader());
+                    Thread.currentThread().setContextClassLoader(DEFAULT_LOADER);
                 }
             }
         }


### PR DESCRIPTION
javax.security.auth.login.LoginContext use context class loader to load the login module, when configuring "sasl.jaas.config", we could set the value as `org.apache.skywalking.apm.dependencies.org.apache.kafka.common.security.scram.ScramLoginModule required username="user" password="pass";`, and the context class loader would load the class correctly, otherwise, NoClassFoundException would be thrown
